### PR TITLE
Improve operator rule

### DIFF
--- a/src/caddy65.c
+++ b/src/caddy65.c
@@ -418,7 +418,7 @@ result_t applyRule(rule_t rule, char * const source, regex_t * regex) {
                     strcpy(source, scratch);
                     result = applied;
                 }
-                
+
                 result_t next = applyRule(rule, source + match[1].rm_so + (1 - s3) + s2 + (s7 > 0) + s7, regex);
                 return next > result ? next : result;
             }

--- a/src/caddy65.c
+++ b/src/caddy65.c
@@ -17,7 +17,6 @@ const int pedantic = 0;
 
 char scratch[4096];
 int indentionSize;
-int baseIndentAmount;
 
 #define spacing "([[:space:]]*)"
 #define comment spacing ";" spacing "(.?)"
@@ -405,7 +404,7 @@ result_t applyRule(rule_t rule, char * const source, regex_t * regex) {
 
                 if (s1 != 1 || s4 != 1) {
                     sprintf(scratch, "%.*s %.*s %s",
-                        (int)match[1].rm_so, source,
+                        (int) match[1].rm_so, source,
                         s2, source + match[2].rm_so,
                         source + match[4].rm_eo);
                     strcpy(source, scratch);


### PR DESCRIPTION
Operator rule currently doesn't match two character operators, matches them as single characters first. It also can jump too far ahead in the source string when calling applyRule() again on the rest of the source line.
Non working example: `foo         & 1    +   3` results in: `foo & 1    +   3`  as it starts the next applyRule at the old & operator position. These changes address these issues. 
Also, just use group 3 for dot operators.
Note: I am using pcreposix for regex with Visual Studio, but I think the regex matches are working as expected.